### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.4.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.npm
           key: npm
@@ -38,17 +38,17 @@ jobs:
     needs: test
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.0.0
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.1.1
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -62,9 +62,9 @@ jobs:
       SPACE_NAME: cdn.samarchyan.me
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
-      - uses: BetaHuhn/do-spaces-action@v2
+      - uses: BetaHuhn/do-spaces-action@v2.0.69
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY}}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}
@@ -73,7 +73,7 @@ jobs:
           source: cdn
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.1.1
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -87,10 +87,10 @@ jobs:
       PROJECT: homepage
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v2.1
+        uses: azure/setup-kubectl@v3.0
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v2.1
+        uses: azure/setup-kubectl@v3.0
 
       - name: Configure kubectl
         run: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[digitalocean/action-doctl](https://github.com/digitalocean/action-doctl)** published a new release [v2.1.1](https://github.com/digitalocean/action-doctl/releases/tag/v2.1.1) on 2022-02-14T15:16:01Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.4.1](https://github.com/actions/setup-node/releases/tag/v3.4.1) on 2022-07-14T10:48:29Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release [v2.0.0](https://github.com/docker/login-action/releases/tag/v2.0.0) on 2022-05-05T17:05:34Z
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release [v2.0.69](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.69) on 2022-08-23T01:31:31Z
* **[azure/setup-kubectl](https://github.com/azure/setup-kubectl)** published a new release [v3.0](https://github.com/Azure/setup-kubectl/releases/tag/v3.0) on 2022-06-21T16:19:02Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release [v2.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.0.0) on 2022-05-05T16:48:01Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.8](https://github.com/actions/cache/releases/tag/v3.0.8) on 2022-08-22T06:49:51Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release [v3.1.1](https://github.com/docker/build-push-action/releases/tag/v3.1.1) on 2022-08-05T13:29:18Z
