### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
 
-      - uses: BetaHuhn/do-spaces-action@v2.0.69
+      - uses: BetaHuhn/do-spaces-action@v2.0.70
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY}}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release [v2.0.70](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.70) on 2022-08-29T02:39:34Z
