### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4.0.2
         with:
           path: ~/.npm
           key: npm
@@ -38,17 +38,17 @@ jobs:
     needs: test
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3.3.0
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v5.3.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -62,9 +62,9 @@ jobs:
       SPACE_NAME: cdn.samarchyan.me
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.6
 
-      - uses: BetaHuhn/do-spaces-action@v2.0.84
+      - uses: BetaHuhn/do-spaces-action@v2.0.146
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY}}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}
@@ -73,7 +73,7 @@ jobs:
           source: cdn
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.2.0
+        uses: digitalocean/action-doctl@v2.5.1
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -87,10 +87,10 @@ jobs:
       PROJECT: homepage
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.6
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v4.0.0
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.6
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v4.0.0
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -15,7 +15,7 @@ jobs:
       COMMITTER_EMAIL: desecho@gmail.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.1.6
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.2.0](https://github.com/docker/login-action/releases/tag/v3.2.0)** on 2024-05-28T08:07:54Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.3.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.3.0)** on 2024-04-08T08:06:08Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.3.0](https://github.com/docker/build-push-action/releases/tag/v5.3.0)** on 2024-03-14T08:32:47Z
* **[azure/setup-kubectl](https://github.com/azure/setup-kubectl)** published a new release **[v4.0.0](https://github.com/Azure/setup-kubectl/releases/tag/v4.0.0)** on 2024-02-07T18:11:50Z
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release **[v2.0.146](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.146)** on 2024-02-12T01:16:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.6](https://github.com/actions/checkout/releases/tag/v4.1.6)** on 2024-05-16T18:11:28Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[digitalocean/action-doctl](https://github.com/digitalocean/action-doctl)** published a new release **[v2.5.1](https://github.com/digitalocean/action-doctl/releases/tag/v2.5.1)** on 2024-01-26T15:08:40Z
